### PR TITLE
Add listings-ceylon package

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,9 @@ Published on the official marketplace: https://marketplace.visualstudio.com/item
     ext install Ceylon
 
 Our source : https://github.com/bjansen/vs.language.ceylon
+
+## LaTeX listings
+
+This is not published on CTAN yet.
+
+Our source: https://github.com/lucaswerkmeister/listings-ceylon/


### PR DESCRIPTION
This package provides Ceylon syntax highlighting for the LaTeX listings package, which as far as I’m aware is the most popular package for syntax highlighting in the TeX world.